### PR TITLE
fix: vCluster CLI should not use platform /version endpoint

### DIFF
--- a/pkg/platform/clihelper/clihelper.go
+++ b/pkg/platform/clihelper/clihelper.go
@@ -351,26 +351,13 @@ func IsLoftReachable(ctx context.Context, host string) (bool, error) {
 	client := &http.Client{
 		Transport: utilhttp.InsecureTransport(),
 	}
-	url := "https://" + host + "/version"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	endpoint := fmt.Sprintf("https://%s/healthz", host)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return false, fmt.Errorf("error creating request with context: %w", err)
 	}
 	resp, err := client.Do(req)
 	if err == nil && resp.StatusCode == http.StatusOK {
-		out, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return false, nil
-		}
-
-		v := &version{}
-		err = json.Unmarshal(out, v)
-		if err != nil {
-			return false, fmt.Errorf("error decoding response from %s: %w. Try running '%s --reset'", url, err, product.StartCmd())
-		} else if v.Version == "" {
-			return false, fmt.Errorf("unexpected response from %s: %s. Try running '%s --reset'", url, string(out), product.StartCmd())
-		}
-
 		return true, nil
 	}
 


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
resolves #ENG-8958


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster platform start` used an authenticated endpoint to check wheter vCluster Platform is reachable or not. 

**What else do we need to know?** 
Because `/healthz` endpoint normally returns an empty body, I had to remove the logic where the data structure of `/version` was parsed and specific errors were thrown in applicable cases. 

